### PR TITLE
[core] fix: validate option fields and add tests

### DIFF
--- a/tagbox-core/src/authors.rs
+++ b/tagbox-core/src/authors.rs
@@ -1,6 +1,6 @@
 use crate::errors::{Result, TagboxError};
 use crate::types::Author;
-use crate::utils::{current_time, generate_uuid};
+use crate::utils::{current_time, generate_uuid, require_field};
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use tracing::{debug, info};
@@ -61,7 +61,7 @@ impl AuthorManager {
         let metadata = self.get_author_metadata(author_id_param).await?;
         
         Ok(Author {
-            id: author_row.id.unwrap_or_default(),
+            id: require_field(author_row.id, "authors.id")?,
             name: author_row.name,
             aliases: alias_names, // Use the fetched alias names
             metadata: Some(metadata),
@@ -82,7 +82,7 @@ impl AuthorManager {
         .map_err(|e| TagboxError::Database(e))?;
         
         if let Some(author) = existing {
-            return self.get_author(&author.id.unwrap_or_default()).await;
+            return self.get_author(&require_field(author.id, "authors.id")?).await;
         }
         
         // 创建新作者

--- a/tagbox-core/src/editor.rs
+++ b/tagbox-core/src/editor.rs
@@ -3,7 +3,7 @@
 use sqlx::{SqlitePool, sqlite::SqliteArguments, Arguments};
 use crate::types::{FileUpdateRequest, QueryParam}; // Assuming FileUpdateRequest is in types.rs
 use crate::errors::{Result, TagboxError}; // Assuming Result and TagboxError are in errors.rs
-use crate::utils::current_time; // Assuming current_time is in utils.rs
+use crate::utils::{current_time, require_field}; // Assuming current_time is in utils.rs
 
 pub struct Editor {
     db_pool: SqlitePool,
@@ -287,7 +287,7 @@ impl Editor {
         .map_err(TagboxError::Database)?
         .ok_or_else(|| TagboxError::InvalidFileId(file_id.to_string()))?;
 
-        Ok(std::path::PathBuf::from(file_path.relative_path.unwrap_or_default()))
+        Ok(std::path::PathBuf::from(require_field(file_path.relative_path, "files.relative_path")?))
     }
 
     /// 获取文件信息
@@ -336,18 +336,18 @@ impl Editor {
         .collect();
 
         Ok(crate::types::FileEntry {
-            id: file_row.id.unwrap_or_default(),
+            id: require_field(file_row.id, "files.id")?,
             title: file_row.title,
             authors,
             year: file_row.year.map(|y| y as i32),
             publisher: file_row.publisher,
             source: file_row.source_url,
-            path: std::path::PathBuf::from(file_row.relative_path.unwrap_or_default()),
+            path: std::path::PathBuf::from(require_field(file_row.relative_path, "files.relative_path")?),
             original_path: None,
-            original_filename: file_row.filename.unwrap_or_default(),
-            hash: file_row.initial_hash.unwrap_or_default(),
+            original_filename: require_field(file_row.filename, "files.filename")?,
+            hash: require_field(file_row.initial_hash, "files.initial_hash")?,
             current_hash: file_row.current_hash,
-            category1: file_row.category_id.unwrap_or_default(),
+            category1: require_field(file_row.category_id, "files.category_id")?,
             category2: None,
             category3: None,
             tags,

--- a/tagbox-core/src/errors.rs
+++ b/tagbox-core/src/errors.rs
@@ -39,6 +39,9 @@ pub enum TagboxError {
     
     #[error("未找到关联: 文件 {file_id_a} 和 {file_id_b}")]
     LinkNotFound { file_id_a: String, file_id_b: String },
+
+    #[error("missing required field: {field}")]
+    MissingField { field: String },
 }
 
 pub type Result<T> = std::result::Result<T, TagboxError>;

--- a/tagbox-core/src/importer.rs
+++ b/tagbox-core/src/importer.rs
@@ -3,7 +3,7 @@ use crate::errors::{Result, TagboxError};
 use crate::metainfo::MetaInfoExtractor;
 use crate::pathgen::PathGenerator;
 use crate::types::{FileEntry, ImportMetadata};
-use crate::utils::{calculate_file_hash, ensure_dir_exists, generate_uuid, current_time, safe_copy_file};
+use crate::utils::{calculate_file_hash, ensure_dir_exists, generate_uuid, current_time, safe_copy_file, require_field};
 use std::path::{Path, PathBuf};
 use tracing::{info, debug, warn};
 use sqlx::SqlitePool;
@@ -145,12 +145,12 @@ impl Importer {
                 year: db_row.year.map(|y| y as i32),
                 publisher: db_row.publisher,
                 source: db_row.source_url,
-                path: db_row.relative_path.map(PathBuf::from).unwrap_or_default(),
+                path: PathBuf::from(require_field(db_row.relative_path, "files.relative_path")?),
                 original_path: None,
-                original_filename: db_row.filename.unwrap_or_default(),
-                hash: db_row.initial_hash.unwrap_or_default(),
+                original_filename: require_field(db_row.filename, "files.filename")?,
+                hash: require_field(db_row.initial_hash, "files.initial_hash")?,
                 current_hash: db_row.current_hash,
-                category1: db_row.category_id.unwrap_or_default(),
+                category1: require_field(db_row.category_id, "files.category_id")?,
                 category2: None,
                 category3: None,
                 tags,

--- a/tagbox-core/src/lib.rs
+++ b/tagbox-core/src/lib.rs
@@ -1,10 +1,10 @@
-mod config;
-mod errors;
+pub mod config;
+pub mod errors;
 mod schema;
-mod types;
-mod utils;
+pub mod types;
+pub mod utils;
 mod metainfo;
-mod pathgen;
+pub mod pathgen;
 mod importer;
 mod search;
 mod editor;

--- a/tagbox-core/src/pathgen.rs
+++ b/tagbox-core/src/pathgen.rs
@@ -145,3 +145,16 @@ impl PathGenerator {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_filename() {
+        let cfg = AppConfig::default();
+        let generator = PathGenerator::new(cfg);
+        let cleaned = generator.sanitize_filename(" bad/na?me.txt ");
+        assert_eq!(cleaned, "bad_na_me_txt");
+    }
+}

--- a/tagbox-core/src/search.rs
+++ b/tagbox-core/src/search.rs
@@ -1,5 +1,6 @@
 use crate::config::AppConfig;
 use crate::errors::{Result, TagboxError};
+use crate::utils::require_field;
 use crate::types::{FileEntry, SearchOptions, SearchResult, QueryParam};
 use sqlx::{sqlite::SqlitePoolOptions, SqlitePool, Row, query::Query, sqlite::SqliteArguments, Arguments};
 use std::path::PathBuf;
@@ -694,7 +695,7 @@ impl Searcher {
         
         let mut map = HashMap::new();
         for row in metadata {
-            map.insert(row.key, row.value.unwrap_or_default());
+            map.insert(row.key, require_field(row.value, "file_metadata.value")?);
         }
         
         Ok(map)

--- a/tagbox-core/src/utils.rs
+++ b/tagbox-core/src/utils.rs
@@ -148,3 +148,8 @@ fn generate_backup_path(path: &Path) -> Result<PathBuf> {
         Ok(PathBuf::from(backup_filename))
     }
 }
+
+/// Ensure an Option contains a value, otherwise return `TagboxError::MissingField`.
+pub fn require_field<T>(opt: Option<T>, field: &str) -> Result<T> {
+    opt.ok_or_else(|| TagboxError::MissingField { field: field.to_string() })
+}

--- a/tagbox-core/tests/config_tests.rs
+++ b/tagbox-core/tests/config_tests.rs
@@ -27,6 +27,9 @@ async fn test_load_and_validate_config() {
         path = "./db.sqlite"
         journal_mode = "WAL"
         sync_mode = "NORMAL"
+
+        [hash]
+        algorithm = "blake2b"
     "#;
     fs::write(&config_path, toml).unwrap();
 

--- a/tagbox-core/tests/option_tests.rs
+++ b/tagbox-core/tests/option_tests.rs
@@ -1,0 +1,17 @@
+use tagbox_core::utils::require_field;
+use tagbox_core::errors::TagboxError;
+
+#[test]
+fn test_require_field_some() {
+    let v = require_field(Some(42), "num").unwrap();
+    assert_eq!(v, 42);
+}
+
+#[test]
+fn test_require_field_none() {
+    let err = require_field::<i32>(None, "num").unwrap_err();
+    match err {
+        TagboxError::MissingField { field } => assert_eq!(field, "num"),
+        _ => panic!("unexpected error"),
+    }
+}


### PR DESCRIPTION
## Summary
- add `MissingField` error variant
- add `require_field` helper
- use `require_field` in core modules
- export modules for tests
- expand config test and add option tests
- add sanitize filename unit test

## Testing
- `cargo test --all --offline`